### PR TITLE
Respect layer visibility status

### DIFF
--- a/cartographer.lua
+++ b/cartographer.lua
@@ -110,7 +110,9 @@ end
 
 function Layer.group:draw()
 	for _, layer in ipairs(self.layers) do
-		layer:draw()
+		if layer.visible then
+			layer:draw()
+		end
 	end
 end
 
@@ -179,7 +181,9 @@ end
 function Map:draw()
 	self:_drawBackground()
 	for _, layer in ipairs(self.layers) do
-		layer:draw()
+		if layer.visible then
+			layer:draw()
+		end
 	end
 end
 


### PR DESCRIPTION
We only want to draw each layer if the visible property is set to true.

Note: we need to check layers within a group. Even if the group is set to visible the individual layers inside it may not be.