### PR TITLE
display helpful error when user gives invalid file path

### DIFF
--- a/cartographer.lua
+++ b/cartographer.lua
@@ -303,10 +303,10 @@ end
 function cartographer.load(path)
 	local ok, chunk = pcall(love.filesystem.load, path)
 	if not ok then
-		error('Error loading map from path: ' .. tostring(chunk))
+		error('Error loading map from path: ' .. tostring(chunk), 2)
 	end
 	if not chunk then
-		error('Could not find path: ' .. path)
+		error('Could not find path: ' .. path, 2)
 	end
 	local map = chunk()
 	setmetatable(map, Map)

--- a/cartographer.lua
+++ b/cartographer.lua
@@ -301,7 +301,14 @@ function Map:draw()
 end
 
 function cartographer.load(path)
-	local map = love.filesystem.load(path)()
+	local ok, chunk = pcall(love.filesystem.load, path)
+	if not ok then
+		error('Error loading map from path: ' .. tostring(chunk))
+	end
+	if not chunk then
+		error('Could not find path: ' .. path)
+	end
+	local map = chunk()
 	setmetatable(map, Map)
 	map:_init(path)
 	return map

--- a/cartographer.lua
+++ b/cartographer.lua
@@ -301,6 +301,9 @@ function Map:draw()
 end
 
 function cartographer.load(path)
+	if not path then
+		error('No map path provided', 2)
+	end
 	local ok, chunk = pcall(love.filesystem.load, path)
 	if not ok then
 		error('Error loading map from path: ' .. tostring(chunk), 2)


### PR DESCRIPTION
As a user I want to see a helpful error that tells me that I gave an invalid file or file path so I can more quickly debug my own code.

**before:**
```
Error

cartographer.lua:304: attempt to call a nil value


Traceback

cartographer.lua:304: in function 'load'
main.lua:3: in main chunk
[C]: in function 'require'
[C]: in function 'xpcall'
[C]: in function 'xpcall'
```

**after:**
```
Error

cartographer.lua:309: Could not find path: demo/group.lua


Traceback

[C]: in function 'error'
cartographer.lua:309: in function 'load'
main.lua:4: in main chunk
[C]: in function 'require'
[C]: in function 'xpcall'
[C]: in function 'xpcall'
```