### PR TITLE
Fix #5: Respect tileset.margin when creating quads

### DIFF
--- a/cartographer.lua
+++ b/cartographer.lua
@@ -788,11 +788,10 @@ function Map:_getTileQuad(gid, frame)
 		id = tile.animation[frame].tileid
 	end
 	local image = self._images[tileset.image]
-	local gridWidth = math.floor(image:getWidth() / (tileset.tilewidth + tileset.spacing))
-	local x, y = indexToCoordinates(id + 1, gridWidth)
+	local x, y = indexToCoordinates(id + 1, tileset.columns)
 	return love.graphics.newQuad(
-		x * (tileset.tilewidth + tileset.spacing),
-		y * (tileset.tileheight + tileset.spacing),
+		tileset.margin + (x * (tileset.tilewidth + tileset.spacing)),
+		tileset.margin + (y * (tileset.tileheight + tileset.spacing)),
 		tileset.tilewidth, tileset.tileheight,
 		image:getWidth(), image:getHeight()
 	)


### PR DESCRIPTION
I whipped up a testbench with varying margins, and this is what it looked like before the below fixes: 

![image](https://user-images.githubusercontent.com/7221020/97118498-0f463480-176f-11eb-97c1-e7340ac497cd.png)

And then after:

![image](https://user-images.githubusercontent.com/7221020/97118516-2edd5d00-176f-11eb-8a01-fcf6214ee725.png)

I'm not happy with my solution though - the modification to `imageWidth` seems correct, but converting the `floor` to round the number instead feels wrong - I can't put my finger on why, though. Either way, the `gridWidth` is spat out on the other side as equal for every test in the above image.

On top of that a margin of `2 * tileWidth` is failing still by what looks like an off-by-one error. I've marked the commit as a `DRAFT` until my monkey brain can figure it out.

I was gonna share the test bench, but it contains assets from that big `itch` bundle that I'm probably not allowed to attach to a public PR haha.